### PR TITLE
Added CM Blog Post 2021/10/05

### DIFF
--- a/articles/mecm/20180302_01.md
+++ b/articles/mecm/20180302_01.md
@@ -1,0 +1,244 @@
+---
+title: Microsoft Endpoint Configuration Manager (MECM) におけるウイルス対策ソフトの除外設定について
+date: 2018-03-02
+tags:
+  - MECM
+---
+
+# Microsoft Endpoint Configuration Manager (MECM) におけるウイルス対策ソフトの除外設定について
+
+こんにちは。Configuration Manager サポートチームです。  
+Microsoft Endpoint Configuration Manager (MECM) をご利用いただく中でウイルス対策ソフトによるリアルタイムスキャン機能の影響により、コンテンツのダウンロードが阻害されて失敗する等、意図しない動作が発生する事があります。この場合、MECM が使用するフォルダーをスキャンの除外対象にすることが問題の解決につながる場合が多くございます。
+また、ウイルス対策ソフトでの除外リストの情報については複数の公開情報に分散されている事もございますので、ここでは MECM をご利用いただく上で関連する製品についてのウイルス対策ソフトご利用時における除外設定の一覧をおまとめいたしました。
+MECM 環境をウイルス対策ソフトと共にご利用いただく際には本情報を参考に除外設定を実施いただけますと幸いです。
+なお、以下で記載させていただいております各種パスにつきましては主に既定のパス情報を基に記載しておりますので、インストール パスを変更いただいている環境等では適宜読み替えてご確認ください。
+([フォルダパス] についてはサブフォルダおよびファイルを含む除外指定となります。)
+(ご利用の環境ならびに構成によっては一部存在しないものもございます。)  
+
+## 1. Microsoft Endpoint Configuration Manager サーバー  
+[ファイルパス]  
+%allusersprofile%\NTUser.pol  
+%systemroot%\system32\GroupPolicy\Machine\registry.pol  
+%systemroot%\system32\GroupPolicy\User\registry.pol  
+%systemroot%\system32\GroupPolicy\registry.pol   
+%systemroot%\Security\database\*.chk  
+%systemroot%\Security\database\*.edb  
+%systemroot%\Security\database\*.jrs  
+%systemroot%\Security\database\*.log  
+%systemroot%\Security\database\*.sdb  
+%systemroot%\SoftwareDistribution\Datastore\Datastore.edb  
+%systemroot%\SoftwareDistribution\Datastore\Logs\edb.chk  
+%systemroot%\SoftwareDistribution\Datastore\Logs\edb*.log  
+%systemroot%\SoftwareDistribution\Datastore\Logs\Res*.log  
+%systemroot%\SoftwareDistribution\Datastore\Logs\Res*.jrs  
+%systemroot%\SoftwareDistribution\Datastore\Logs\edb*.jrs  
+%systemroot%\SoftwareDistribution\Datastore\Logs\tmp.edb  
+%programfiles%\Microsoft Configuration Manager\Install.map  
+%systemroot%\SoftwareDistribution\Datastore\Logs\Edbres00001.jrs   
+%systemroot%\SoftwareDistribution\Datastore\Logs\Edbres00002.jrs  
+%systemroot%\SoftwareDistribution\Datastore\Logs\Res1.log  
+%systemroot%\SoftwareDistribution\Datastore\Logs\Res2.log  
+
+[フォルダパス]  
+%programfiles%\Microsoft Configuration Manager\Inboxes\adsrv.box    
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\adsrv.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\AIKbMgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\AIKbMgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\amtproxymgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\amtproxymgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\auth.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\auth.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\ccr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\ccr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\ccrretry.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\ccrretry.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\certmgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\certmgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\clifiles.src  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\clifiles.src  
+%programfiles%\Microsoft Configuration Manager\Inboxes\colfile.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\colfile.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\coll_out.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\coll_out.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\COLLEVAL.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\COLLEVAL.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\CompSumm.Box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\CompSumm.Box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\dataldr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\dataldr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\ddm.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\ddm.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\ddmnotif.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\ddmnotif.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\despoolr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\despoolr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\distmgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\distmgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\epmgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\epmgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\hman.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\hman.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\inventry.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\inventry.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\invproc.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\invproc.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\mmctrl.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\mmctrl.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\notictrl.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\notictrl.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\objmgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\objmgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\offermgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\offermgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\OfferSum.Box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\OfferSum.Box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\pkginfo.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\pkginfo.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\PkgTransferMgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\PkgTransferMgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\policypv.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\policypv.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\polreq.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\polreq.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\rcm.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\rcm.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\replmgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\replmgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\RuleEngine.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\RuleEngine.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\schedule.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\schedule.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\sinv.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\sinv.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\sitecomp.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\sitecomp.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\sitectrl.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\sitectrl.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\SiteStat.Box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\SiteStat.Box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\smsbkup.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\smsbkup.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\statmgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\statmgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\swmproc.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\swmproc.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\WSUSMgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\WSUSMgr.box  
+%programfiles%\Microsoft Configuration Manager\Inboxes\wsyncmgr.box  
+%programfiles(x86)%\Microsoft Configuration Manager\Inboxes\wsyncmgr.box  
+\SCCMContentLib  
+\SMSPKG  
+\SMSPKG[driveletter]$  
+\SMSPKGSIG  
+\SMSSIG$  
+\SMS_DP$  
+%programfiles%\SMS_CCM\ServiceData  
+%programfiles%\SMS_CCM\Logs  
+%programfiles%\Microsoft Configuration Manager\Logs  
+%systemroot%\TEMP\BootImages  
+\ConfigMgr_OfflineImageServicing  
+%systemroot%\SoftwareDistribution\Download  
+%SystemDrive%\_SMSTaskSequence  
+\ConfigMgrBackupDirectory (例: D:\SCCMBackup)  
+\ConfigMgrPackageSourceFiles (例: D:\SCCMSource)  
+%programfiles%\Microsoft Configuration Manager\cd.latest  
+%programfiles%\Microsoft Configuration Manager\EasySetupPayload  
+%programfiles%\Microsoft Configuration   Manager\AdminUIContentPayload  
+%programfiles%\Microsoft Configuration   Manager\AdminUIContentStaging  
+%programfiles%\Microsoft Configuration Manager\CMUStaging  
+%programfiles%\Microsoft Configuration Manager\CMUClient  
+%programfiles%\Microsoft Configuration Manager\PilotingUpgrade  
+%programfiles%\Microsoft Configuration Manager\RLAStaging  
+%programfiles%\Microsoft Configuration Manager\CMProviderLog  
+
+[プロセス]  
+%programfiles%\Microsoft Configuration Manager\bin\x64\Smsexec.exe  
+%programfiles%\Microsoft Configuration Manager\bin\x64\Sitecomp.exe  
+%programfiles%\Microsoft Configuration Manager\bin\x64\Smswriter.exe  
+%programfiles%\Microsoft Configuration Manager\bin\x64\Smssqlbbkup.exe  
+%programfiles%\Microsoft Configuration Manager\bin\x64\Cmupdate.exe  
+%systemroot%\CCM\Ccmexec.exe  
+%systemroot%\SMS_CCM\Ccmexec.exe  
+%systemroot%\CCM\CmRcService.exe  
+\SMS_[SQLFQDN]\bin\x64\Smssqlbbkup.exe  
+ 
+ ## 2. Microsoft Endpoint Configuration Manager クライアント
+ [ファイルパス]  
+%systemroot%\Security\database\*.chk  
+%systemroot%\Security\database\*.edb  
+%systemroot%\Security\database\*.jrs  
+%systemroot%\Security\database\*.log  
+%systemroot%\Security\database\*.sdb  
+%allusersprofile%\NTUser.pol  
+%systemroot%\system32\GroupPolicy\Machine\registry.pol  
+%systemroot%\system32\GroupPolicy\User\registry.pol  
+
+[フォルダパス]  
+%systemroot%\ccmcache  
+%SystemRoot%\SoftwareDistribution\Datastore  
+%systemroot%\SoftwareDistribution\Download  
+%systemroot%\CCM\*.sdf  
+%systemroot%\CCM\Logs  
+%systemroot%\CCM\ServiceData    
+%systemroot%\CCMSetup  
+
+[プロセス]  
+%systemroot%\CCM\Ccmexec.exe  
+%systemroot%\CCM\CmRcService.exe  
+%systemroot%\CCMRemCtrl\CmRcService.exe  
+%systemroot%\CCM\Ccmrepair.exe  
+%systemroot%\ccmsetup\Ccmsetup.exe  
+
+## 3. SQL Server
+[ファイル拡張子]  
+*.mdf  
+*.ldf  
+*.ndf  
+*.bak  
+*.trn  
+*.trc  
+*.sqlaudit  
+*.sql  
+
+[フォルダパス]  
+\Program Files\Microsoft SQL Server\.\OLAP\Backup  
+\Program Files\Microsoft SQL Server\.\OLAP\Log  
+\Program Files\Microsoft SQL Server\.\MSSQL\FTData  
+\QuorumDrive (例： Q:\)  
+%systemroot%\Cluster  
+
+
+[プロセス]  
+%ProgramFiles%\Microsoft SQL Server\[version].[Instance Name]\MSSQL\Binn\SQLServr.exe   
+%ProgramFiles%\Microsoft SQL Server\[version].[Instance Name]\ReportingServices\ReportServer\Bin\ReportingServicesService.exe    
+%ProgramFiles%\Microsoft SQL Server\.\OLAP\Bin\MSMDSrv.exe  
+
+## 4. Internet Information Services (IIS)
+[フォルダパス]  
+%systemroot%\IIS Temporary Compressed Files  
+%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files  
+
+[ファイル拡張子]  
+*.ida  
+
+[プロセス]  
+%systemroot%\system32\inetsrv\w3wp.exe  
+%systemroot%\SysWOW64\inetsrv\w3wp.exe  
+
+## 5. Windows Server Update Services (WSUS)
+[フォルダパス]  
+\WSUS\UpdateServicesDBFiles  
+\WSUS\WSUSContent  
+%systemroot%\SoftwareDistribution\Download  
+%SystemRoot%\SoftwareDistribution\Datastore  
+%ProgramFiles%\Update Services\LogFiles\WSUSTemp  
+
+[ファイル拡張子]  
+*.cab  
+
+## - 参考資料
+Microsoft Anti-Virus Exclusion List
+http://social.technet.microsoft.com/wiki/contents/articles/953.microsoft-anti-virus-exclusion-list.aspx
+
+Virus scanning recommendations for Enterprise computers that are running currently supported versions of Windows
+https://support.microsoft.com/en-us/topic/virus-scanning-recommendations-for-enterprise-computers-that-are-running-currently-supported-versions-of-windows-kb822158-c067a732-f24a-9079-d240-3733e39b40bc


### PR DESCRIPTION
「Microsoft Endpoint Configuration Manager (MECM) におけるウイルス対策ソフトの除外設定について」
こちらの Blog の記載が完了しましたので、ご確認お願いいたします。