### PR TITLE
Update BingSiteAuth.xml

### DIFF
--- a/source/BingSiteAuth.xml
+++ b/source/BingSiteAuth.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <users>
-	<user>F16E0694A9E5878E58E0F77B3CB4A700</user>
+	<user>F46C04EB4E1832EEDC341AC0CE6CA50E</user>
 </users>


### PR DESCRIPTION
Bing Web Master Tools 経由でクロール対象に追加するため、サイトの所有者の認証用のファイルを差し替えます。

/blog/BingSiteAuth.xml で公開されている既存のファイルの差し替えのため、記事の表示に影響はないです。